### PR TITLE
add no shortcut flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "deadlock-rpc"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "dirs",
  "discord-rich-presence",

--- a/src/main.rs
+++ b/src/main.rs
@@ -308,7 +308,9 @@ fn main() {
 
     // Only install the shortcut in release builds so dev runs don't overwrite it with a debug path.
     #[cfg(not(debug_assertions))]
-    launcher::install_shortcut();
+    if !args.iter().any(|a| a == "--no-shortcut") {
+        launcher::install_shortcut();
+    }
 
     if !no_launch {
         launcher::launch_deadlock();

--- a/src/main.rs
+++ b/src/main.rs
@@ -294,6 +294,8 @@ fn main() {
     let no_launch_flag = args.iter().any(|a| a == "--no-launch");
     // --no-launch CLI flag always overrides auto_launch, even if config enables it.
     let no_launch = no_launch_flag || !cfg.general.launch_game_on_start;
+    #[cfg(not(debug_assertions))]
+    let no_shortcut = args.iter().any(|a| a == "--no-shortcut");
 
     if instance_lock.is_none() {
         if !no_launch_flag {
@@ -308,7 +310,7 @@ fn main() {
 
     // Only install the shortcut in release builds so dev runs don't overwrite it with a debug path.
     #[cfg(not(debug_assertions))]
-    if !args.iter().any(|a| a == "--no-shortcut") {
+    if !no_shortcut {
         launcher::install_shortcut();
     }
 


### PR DESCRIPTION
Adds a `--no-shortcut` flag which skips the popup asking to install the shortcut, allowing the process to be added to steam's launch options to run seamlessly only when the game launches using the following launch command, though im not sure what the equivalent would be for windows to run the rpc in parallel with the game
```sh
%command% -condebug & /path/to/deadlock-rpc --no-launch --no-shortcut
```