### PR TITLE
chore: skip weekly release when only non-shipping files changed

### DIFF
--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -4,7 +4,12 @@ on:
   schedule:
     # Every Tuesday at 13:00 UTC. Adjust as needed.
     - cron: "0 13 * * 2"
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Release even if only docs/CI files changed"
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -35,9 +40,42 @@ jobs:
           count=$(git rev-list "${latest_tag}..HEAD" --count)
           echo "Commits since $latest_tag: $count"
           if [ "$count" -eq 0 ]; then
+            echo "No commits since $latest_tag; nothing to release."
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
-          else
+            exit 0
+          fi
+
+          # Only ship a release when something users actually run has changed.
+          # Docs, licence text, CI config and editor/agent files are excluded:
+          # a release for those would prompt every user to download a binary
+          # that is byte-for-byte the same behaviour as the one they have.
+          #
+          # KEEP THIS LIST CURRENT: any new file that does not ship to users
+          # belongs here. See "Adding Non-Shipping Files" in CLAUDE.md.
+          # Note that release.yml and assets/ are intentionally NOT excluded.
+          significant=$(git diff --name-only "${latest_tag}..HEAD" -- . \
+            ':(exclude)*.md' \
+            ':(exclude)docs/**' \
+            ':(exclude)LICENSE' \
+            ':(exclude).github/ISSUE_TEMPLATE/**' \
+            ':(exclude).github/workflows/ci.yml' \
+            ':(exclude).github/workflows/weekly-release.yml' \
+            ':(exclude).claude/**' \
+            ':(exclude).gitignore')
+
+          echo "All files changed since $latest_tag:"
+          git diff --name-only "${latest_tag}..HEAD"
+
+          if [ -n "$significant" ]; then
+            echo "Release-worthy changes:"
+            echo "$significant"
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          elif [ "${{ inputs.force }}" = "true" ]; then
+            echo "Only docs/CI changes, but force was requested; releasing anyway."
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Only docs/CI changes since $latest_tag; skipping release."
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Compute next version

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,31 @@ After any code change, always verify both of the following before reporting the 
 
 If clippy reports warnings, fix them before finishing.
 
+## Adding Non-Shipping Files
+
+`.github/workflows/weekly-release.yml` decides whether to cut a weekly release by diffing
+`<latest tag>..HEAD` with an exclusion pathspec. If that diff is empty after exclusions, the
+release is skipped. This exists so a docs-only week does not bump the version, publish a
+release, and prompt every user to download a functionally identical binary.
+
+**Whenever you add a file or directory that does not ship to users and does not change runtime
+behaviour, add it to that exclusion list in the same change.** Typical cases: new docs, editor
+or agent config, contributor tooling, CI-only workflows, issue/PR templates, screenshots used
+only in the README.
+
+Currently excluded: `*.md`, `docs/**`, `LICENSE`, `.github/ISSUE_TEMPLATE/**`,
+`.github/workflows/ci.yml`, `.github/workflows/weekly-release.yml`, `.claude/**`, `.gitignore`.
+
+Deliberately **not** excluded, do not add these:
+
+- `.github/workflows/release.yml` decides what goes into the zip, so packaging changes there
+  are user-facing.
+- `assets/**` ships inside the package.
+- Anything under `src/` or the Cargo manifests.
+
+When in doubt, ask: "if a user installed this release, would anything be different for them?"
+If no, exclude it.
+
 ## Config Changes
 
 `src/config.rs` contains a versioned migration system. Any change to `DEFAULT_TOML` or config defaults that affects **existing users** requires a migration. Follow these steps:


### PR DESCRIPTION
The weekly release job gated on "any commit since the last tag". A week where only the README changed would still bump the version, tag, build, publish a release, and prompt every user via the in-app updater to download a binary with identical behaviour to the one they already have.

## Change

The check step now gates on *which files* changed, not just the commit count. It diffs `<latest tag>..HEAD` through an exclusion pathspec; if nothing significant remains, `has_changes=false` and every downstream step (bump, tag, build, publish) is skipped.

Excluded: `*.md`, `docs/**`, `LICENSE`, `.github/ISSUE_TEMPLATE/**`, `.github/workflows/ci.yml`, `.github/workflows/weekly-release.yml`, `.claude/**`, `.gitignore`.

Deliberately **not** excluded:

- `.github/workflows/release.yml`, it determines what goes into the zip, so packaging changes there are user-facing.
- `assets/**`, the icons ship inside the package.
- Anything under `src/` or the Cargo manifests.

The step logs both the full changed-file list and the release-worthy subset, so a skipped week is explainable from the run log.

`workflow_dispatch` gains a `force` boolean input to cut a release manually on an otherwise-skipped week.

## Keeping the list current

Added an "Adding Non-Shipping Files" section to `CLAUDE.md` making it a standing rule that new non-shipping files get added to the exclusion list in the same change, plus a pointer comment in the workflow itself.

## Verification

- Replayed the pathspec against real history: `163b2c5..e1127a3` (README only) returns nothing; `v1.0.4..HEAD` returns the six source and manifest files.
- YAML parses.
- `cargo clippy -- -D warnings` clean.
- This PR is its own test case: it touches only excluded files, so the first scheduled run after merge should skip.