### PR TITLE
docs: link the interactive demo from the README preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@
 
 <div align="center">
   <img src="assets/demo.gif" alt="Deadlock Discord Rich Presence showing hero portrait, match mode, and game phase updating live on a Discord profile card" />
+
+  **[Try the interactive demo →](https://heytariq.github.io/deadlock-rpc/demo/)**
+
+  Switch heroes, game phases, and portrait styles in your browser and watch the
+  Discord card update live. Nothing to install.
+
 </div>
 
 ## Features


### PR DESCRIPTION
Adds two lines under the preview gif pointing at the browser sandbox at [/demo/](https://heytariq.github.io/deadlock-rpc/demo/), so readers can try the settings right after seeing the static demo.

Kept inside the existing `## Preview` section rather than adding a new heading, to avoid a `## Contents` entry for two lines.

`*.md` is already excluded in `weekly-release.yml`, so this does not trigger a release.