### PR TITLE
feat: show current match duration in rich presence

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ When a release renames or restructures config keys, the release includes a migra
 | Key | Default | Description |
 |-----|---------|-------------|
 | `presence.show_hero_image` | `true` | Show the hero image and name. |
-| `presence.show_match_timer` | `true` | Show how long the current match has been running. Added to the in-match status line, or placed with `{timer}` if `presence.status.in_match` uses that variable. Shown in minutes. |
+| `presence.show_match_timer` | `true` | Show how long the current match has been running. Shown as a clock, e.g. `07:42` (`1:07:42` past an hour). Added to the in-match status line, or placed with `{timer}` if `presence.status.in_match` uses that variable. |
 | `presence.show_statlocker_button` | `false` | Show a "View on Statlocker" button linking to your match history. Only visible to other Discord users, not yourself. |
 | `presence.hero_portrait_style` | `"normal"` | Hero portrait art style. Options: `"normal"`, `"gloat"` (celebration crop), `"critical"` (combat crop). |
 | `presence.details_with_hero` | `"Playing as {hero}"` | Top line when a hero is known. |

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ The tray icon's **Settings** menu lets you toggle the most common options withou
 | `general.launch_game_on_start` | Launch Game on Start |
 | `general.exit_when_game_closes` | Exit When Game Closes |
 | `presence.show_hero_image` | Show Hero Image |
+| `presence.show_match_timer` | Show Match Timer |
 | `presence.show_statlocker_button` | Show Statlocker Button |
 | `presence.hero_portrait_style` | Hero Portrait Style (Normal / Gloat / Critical) |
 
@@ -109,8 +110,8 @@ When a release renames or restructures config keys, the release includes a migra
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `presence.show_elapsed_timer` | `true` | Show the elapsed time counter. |
 | `presence.show_hero_image` | `true` | Show the hero image and name. |
+| `presence.show_match_timer` | `true` | Show how long the current match has been running. Added to the in-match status line, or placed with `{timer}` if `presence.status.in_match` uses that variable. Shown in minutes. |
 | `presence.show_statlocker_button` | `false` | Show a "View on Statlocker" button linking to your match history. Only visible to other Discord users, not yourself. |
 | `presence.hero_portrait_style` | `"normal"` | Hero portrait art style. Options: `"normal"`, `"gloat"` (celebration crop), `"critical"` (combat crop). |
 | `presence.details_with_hero` | `"Playing as {hero}"` | Top line when a hero is known. |
@@ -125,7 +126,7 @@ When a release renames or restructures config keys, the release includes a migra
 | `presence.status.in_hideout` | `"In the Hideout"` |
 | `presence.status.in_matchmaking` | `"Searching for a Match..."` |
 | `presence.status.loading_into_match` | `"{mode} - Loading into Match"` |
-| `presence.status.in_match` | `"In Match: {mode}"` |
+| `presence.status.in_match` | `"In Match: {mode}"` (also supports `{timer}`) |
 | `presence.status.match_location_label` | `"the Cursed Apple"` |
 | `presence.status.post_match` | `"Reviewing Match Results"` |
 | `presence.status.spectating` | `"Spectating a Match"` |

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,6 +58,7 @@ impl HeroPortraitStyle {
 #[serde(default)]
 pub struct PresenceConfig {
     pub show_hero_image: bool,
+    pub show_match_timer: bool,
     pub show_statlocker_button: bool,
     pub hero_portrait_style: HeroPortraitStyle,
     pub details_with_hero: String,
@@ -105,6 +106,7 @@ impl Default for PresenceConfig {
     fn default() -> Self {
         Self {
             show_hero_image: true,
+            show_match_timer: true,
             show_statlocker_button: false,
             hero_portrait_style: HeroPortraitStyle::Normal,
             details_with_hero: "Playing as {hero}".to_string(),
@@ -145,6 +147,7 @@ pub struct SharedBools {
     pub launch_game_on_start: AtomicBool,
     pub exit_when_game_closes: AtomicBool,
     pub show_hero_image: AtomicBool,
+    pub show_match_timer: AtomicBool,
     pub show_statlocker_button: AtomicBool,
     pub hero_portrait_style: AtomicU8,
     // Set by the tray when a presence setting changes so the RPC loop wakes early.
@@ -157,6 +160,7 @@ impl SharedBools {
             launch_game_on_start: AtomicBool::new(cfg.general.launch_game_on_start),
             exit_when_game_closes: AtomicBool::new(cfg.general.exit_when_game_closes),
             show_hero_image: AtomicBool::new(cfg.presence.show_hero_image),
+            show_match_timer: AtomicBool::new(cfg.presence.show_match_timer),
             show_statlocker_button: AtomicBool::new(cfg.presence.show_statlocker_button),
             hero_portrait_style: AtomicU8::new(cfg.presence.hero_portrait_style.as_u8()),
             settings_dirty: AtomicBool::new(false),

--- a/src/default_config.toml
+++ b/src/default_config.toml
@@ -13,6 +13,9 @@ config_version = 2
 
 [presence]
 show_hero_image = true
+# Show how long the current match has been running. Added to the in-match status line, or
+# placed with {timer} if presence.status.in_match uses that variable.
+show_match_timer = true
 # Show a Statlocker button when your Steam ID is detected in the game log.
 show_statlocker_button = false
 # Hero portrait style to display. Options: "normal", "gloat", "critical".
@@ -30,7 +33,7 @@ in_hideout = "In the Hideout"
 in_matchmaking = "Searching for a Match..."
 # Supports {mode} (e.g. "Ranked", "Unranked").
 loading_into_match = "{mode} - Loading into Match"
-# Supports {mode}.
+# Supports {mode} and {timer} (match duration, e.g. "12m").
 in_match = "In Match: {mode}"
 match_location_label = "the Cursed Apple"
 post_match = "Reviewing Match Results"

--- a/src/default_config.toml
+++ b/src/default_config.toml
@@ -13,8 +13,8 @@ config_version = 2
 
 [presence]
 show_hero_image = true
-# Show how long the current match has been running. Added to the in-match status line, or
-# placed with {timer} if presence.status.in_match uses that variable.
+# Show how long the current match has been running, as a clock (e.g. "07:42"). Added to the
+# in-match status line, or placed with {timer} if presence.status.in_match uses that variable.
 show_match_timer = true
 # Show a Statlocker button when your Steam ID is detected in the game log.
 show_statlocker_button = false
@@ -33,7 +33,7 @@ in_hideout = "In the Hideout"
 in_matchmaking = "Searching for a Match..."
 # Supports {mode} (e.g. "Ranked", "Unranked").
 loading_into_match = "{mode} - Loading into Match"
-# Supports {mode} and {timer} (match duration, e.g. "12m").
+# Supports {mode} and {timer} (match duration, e.g. "07:42").
 in_match = "In Match: {mode}"
 match_location_label = "the Cursed Apple"
 post_match = "Reviewing Match Results"

--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -65,13 +65,26 @@ impl GamePhase {
     }
 }
 
+// Renders a match duration for the presence line. Minute granularity on purpose: the presence
+// is only pushed every few seconds, so a seconds counter would read as stale between updates.
+pub fn format_match_elapsed(d: std::time::Duration) -> String {
+    let total_mins = d.as_secs() / 60;
+    if total_mins < 60 {
+        format!("{}m", total_mins)
+    } else {
+        format!("{}h {:02}m", total_mins / 60, total_mins % 60)
+    }
+}
+
 pub struct GameState {
     pub phase: GamePhase,
     pub match_mode: MatchMode,
     pub hero_key: Option<String>,
     pub map_name: Option<String>,
     pub party_size: u8,
-    
+    // Set when the match actually starts, cleared whenever we leave the InMatch phase.
+    pub match_started_at: Option<std::time::Instant>,
+
     // internal tracking
     pub(crate) hero_window_open: bool,
     pub(crate) hideout_loaded: bool,
@@ -89,6 +102,7 @@ impl GameState {
             hero_key: None,
             map_name: None,
             party_size: 1,
+            match_started_at: None,
             hero_window_open: true,
             hideout_loaded: false,
             local_account_id: None,
@@ -104,6 +118,7 @@ impl GameState {
 
     pub fn enter_hideout(&mut self) {
         self.phase = GamePhase::Hideout;
+        self.match_started_at = None;
         self.hero_key = None;
         self.hero_window_open = true;
         self.hideout_loaded = false;
@@ -145,10 +160,12 @@ impl GameState {
 
     pub fn enter_main_menu(&mut self) {
         self.phase = GamePhase::MainMenu;
+        self.match_started_at = None;
     }
 
     pub fn enter_queue(&mut self) {
         self.phase = GamePhase::InQueue;
+        self.match_started_at = None;
     }
 
     pub fn leave_queue(&mut self) {
@@ -157,6 +174,7 @@ impl GameState {
 
     pub fn enter_match_intro(&mut self) {
         self.phase = GamePhase::MatchIntro;
+        self.match_started_at = None;
         self.match_mode = MatchMode::Unknown;
         self.hero_key = None;
         self.hero_window_open = true;
@@ -164,15 +182,29 @@ impl GameState {
     }
 
     pub fn start_match(&mut self) {
+        // Guard against repeated "game in progress" signals restarting the clock.
+        if self.phase != GamePhase::InMatch || self.match_started_at.is_none() {
+            self.match_started_at = Some(std::time::Instant::now());
+        }
         self.phase = GamePhase::InMatch;
     }
 
     pub fn end_match(&mut self) {
         self.phase = GamePhase::PostMatch;
+        self.match_started_at = None;
     }
 
     pub fn enter_spectating(&mut self) {
         self.phase = GamePhase::Spectating;
+        self.match_started_at = None;
+    }
+
+    // How long the current match has been running, or None outside of an active match.
+    pub fn match_elapsed(&self) -> Option<std::time::Duration> {
+        if self.phase != GamePhase::InMatch {
+            return None;
+        }
+        self.match_started_at.map(|t| t.elapsed())
     }
 
     pub fn prepare_match_hero_tracking(&mut self) {
@@ -185,10 +217,12 @@ impl GameState {
     // - `hideout_text`: hero-specific text from the API (takes priority in Hideout phase).
     // - `hero_name`: display name of the current hero (used as `{hero}` variable).
     // - `cfg`: per-phase string templates from the loaded config.
+    // - `timer`: formatted match duration (used as `{timer}`, appended if the template omits it).
     pub fn presence_status(
         &self,
         hideout_text: Option<&str>,
         hero_name: Option<&str>,
+        timer: Option<&str>,
         cfg: &crate::config::StatusStrings,
     ) -> String {
         use crate::config::apply_vars;
@@ -208,14 +242,25 @@ impl GameState {
             }
             GamePhase::InMatch => {
                 let mode = self.match_mode.display();
-                if self.match_mode.show_map_location() {
+                let uses_template = self.match_mode.show_map_location();
+                let mut status = if uses_template {
                     apply_vars(
                         &cfg.in_match,
-                        &[("mode", mode), ("location", &cfg.match_location_label)],
+                        &[
+                            ("mode", mode),
+                            ("location", &cfg.match_location_label),
+                            ("timer", timer.unwrap_or("")),
+                        ],
                     )
                 } else {
                     mode.to_string()
+                };
+                // Templates written before {timer} existed still get the timer, appended.
+                let placed = uses_template && cfg.in_match.contains("{timer}");
+                if let Some(t) = timer.filter(|_| !placed) {
+                    status = format!("{status} - {t}");
                 }
+                status
             }
             GamePhase::PostMatch => cfg.post_match.clone(),
             GamePhase::Spectating => cfg.spectating.clone(),
@@ -252,4 +297,5 @@ impl GameState {
         }
     }
 }
+
 

--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -65,14 +65,16 @@ impl GamePhase {
     }
 }
 
-// Renders a match duration for the presence line. Minute granularity on purpose: the presence
-// is only pushed every few seconds, so a seconds counter would read as stale between updates.
+// Renders a match duration as a clock: "07:42", or "1:07:42" once past an hour.
+// The value is computed at push time, so it is exact when sent and drifts by at most
+// one presence refresh (see MIN_TIMER_REFRESH_SECS in main.rs) before the next push.
 pub fn format_match_elapsed(d: std::time::Duration) -> String {
-    let total_mins = d.as_secs() / 60;
-    if total_mins < 60 {
-        format!("{}m", total_mins)
+    let total = d.as_secs();
+    let (hours, mins, secs) = (total / 3600, (total % 3600) / 60, total % 60);
+    if hours > 0 {
+        format!("{}:{:02}:{:02}", hours, mins, secs)
     } else {
-        format!("{}h {:02}m", total_mins / 60, total_mins % 60)
+        format!("{:02}:{:02}", mins, secs)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ mod tray;
 mod updater;
 
 use discord_rich_presence::{activity, DiscordIpc, DiscordIpcClient};
-use game_state::{GamePhase, GameState, MatchMode};
+use game_state::{format_match_elapsed, GamePhase, GameState, MatchMode};
 use hero_api::{HeroCache, HeroData};
 use log::{info, warn};
 use log_watcher::LogWatcher;
@@ -24,7 +24,17 @@ use std::time::Duration;
 
 const DISCORD_APP_ID: &str = "1474302474474094634";
 
-type LastRpcState = (GamePhase, MatchMode, Option<String>, u8, Option<String>, Option<u64>);
+// Last pushed presence inputs. The trailing Option<String> is the rendered match timer, which
+// changes once a minute and so drives a refresh even when nothing else moved.
+type LastRpcState = (
+    GamePhase,
+    MatchMode,
+    Option<String>,
+    u8,
+    Option<String>,
+    Option<u64>,
+    Option<String>,
+);
 
 fn connect_discord(app_id: &str) -> DiscordIpcClient {
     let mut client = DiscordIpcClient::new(app_id);
@@ -136,9 +146,14 @@ fn run_rpc_loop(state: Arc<Mutex<GameState>>, cfg: config::Config, shared: Arc<c
     let update_interval = Duration::from_secs(cfg.general.discord_update_interval_s);
 
     loop {
-        let (phase, match_mode, hero_key, party_size, map_name, account_id) = {
+        let (phase, match_mode, hero_key, party_size, map_name, account_id, timer_text) = {
             let gs = state.lock().unwrap();
-            (gs.phase, gs.match_mode, gs.hero_key.clone(), gs.party_size, gs.map_name.clone(), gs.local_account_id)
+            let timer_text = if shared.show_match_timer.load(Ordering::Relaxed) {
+                gs.match_elapsed().map(format_match_elapsed)
+            } else {
+                None
+            };
+            (gs.phase, gs.match_mode, gs.hero_key.clone(), gs.party_size, gs.map_name.clone(), gs.local_account_id, timer_text)
         };
 
         if phase != GamePhase::NotRunning {
@@ -151,7 +166,7 @@ std::process::exit(0);
             }
         }
 
-        let current = (phase, match_mode, hero_key.clone(), party_size, map_name, account_id);
+        let current = (phase, match_mode, hero_key.clone(), party_size, map_name, account_id, timer_text.clone());
         if last_state.as_ref() == Some(&current) {
             let deadline = std::time::Instant::now() + update_interval;
             let step = Duration::from_millis(500);
@@ -196,7 +211,7 @@ std::process::exit(0);
 
         let game_status: String = {
             let gs = state.lock().unwrap();
-            gs.presence_status(hideout_text, hero_name, &cfg.presence.status)
+            gs.presence_status(hideout_text, hero_name, timer_text.as_deref(), &cfg.presence.status)
         };
 
         let hero_label: String = match hero_name {

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,8 +24,12 @@ use std::time::Duration;
 
 const DISCORD_APP_ID: &str = "1474302474474094634";
 
-// Last pushed presence inputs. The trailing Option<String> is the rendered match timer, which
-// changes once a minute and so drives a refresh even when nothing else moved.
+// Floor for how often the ticking match timer alone may trigger a presence push, so a low
+// discord_update_interval_s cannot turn the clock into one Discord update per second.
+const MIN_TIMER_REFRESH_SECS: u64 = 5;
+
+// Last pushed presence inputs. The trailing Option<u64> is the match timer's refresh bucket,
+// which advances on its own and so drives a push even when nothing else moved.
 type LastRpcState = (
     GamePhase,
     MatchMode,
@@ -33,7 +37,7 @@ type LastRpcState = (
     u8,
     Option<String>,
     Option<u64>,
-    Option<String>,
+    Option<u64>,
 );
 
 fn connect_discord(app_id: &str) -> DiscordIpcClient {
@@ -144,16 +148,18 @@ fn run_rpc_loop(state: Arc<Mutex<GameState>>, cfg: config::Config, shared: Arc<c
         .unwrap_or(0);
 
     let update_interval = Duration::from_secs(cfg.general.discord_update_interval_s);
+    let timer_refresh_secs = cfg.general.discord_update_interval_s.max(MIN_TIMER_REFRESH_SECS);
 
     loop {
-        let (phase, match_mode, hero_key, party_size, map_name, account_id, timer_text) = {
+        let (phase, match_mode, hero_key, party_size, map_name, account_id, timer_text, timer_bucket) = {
             let gs = state.lock().unwrap();
-            let timer_text = if shared.show_match_timer.load(Ordering::Relaxed) {
-                gs.match_elapsed().map(format_match_elapsed)
+            let elapsed = if shared.show_match_timer.load(Ordering::Relaxed) {
+                gs.match_elapsed()
             } else {
                 None
             };
-            (gs.phase, gs.match_mode, gs.hero_key.clone(), gs.party_size, gs.map_name.clone(), gs.local_account_id, timer_text)
+            let timer_bucket = elapsed.map(|d| d.as_secs() / timer_refresh_secs);
+            (gs.phase, gs.match_mode, gs.hero_key.clone(), gs.party_size, gs.map_name.clone(), gs.local_account_id, elapsed.map(format_match_elapsed), timer_bucket)
         };
 
         if phase != GamePhase::NotRunning {
@@ -166,7 +172,7 @@ std::process::exit(0);
             }
         }
 
-        let current = (phase, match_mode, hero_key.clone(), party_size, map_name, account_id, timer_text.clone());
+        let current = (phase, match_mode, hero_key.clone(), party_size, map_name, account_id, timer_bucket);
         if last_state.as_ref() == Some(&current) {
             let deadline = std::time::Instant::now() + update_interval;
             let step = Duration::from_millis(500);

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -112,6 +112,17 @@ mod linux {
                         }
                         .into(),
                         CheckmarkItem {
+                            label: "Show Match Timer".to_string(),
+                            checked: self.shared.show_match_timer.load(Ordering::Relaxed),
+                            activate: Box::new(|tray: &mut Self| {
+                                let old = tray.shared.show_match_timer.fetch_xor(true, Ordering::Relaxed);
+                                crate::config::set_config_bool("presence", "show_match_timer", !old);
+                                tray.shared.settings_dirty.store(true, Ordering::Relaxed);
+                            }),
+                            ..Default::default()
+                        }
+                        .into(),
+                        CheckmarkItem {
                             label: "Show Statlocker Button".to_string(),
                             checked: self.shared.show_statlocker_button.load(Ordering::Relaxed),
                             activate: Box::new(|tray: &mut Self| {
@@ -318,6 +329,12 @@ mod windows {
             shared.show_hero_image.load(Ordering::Relaxed),
             None,
         );
+        let match_timer_item = CheckMenuItem::new(
+            "Show Match Timer",
+            true,
+            shared.show_match_timer.load(Ordering::Relaxed),
+            None,
+        );
         let statlocker_item = CheckMenuItem::new(
             "Show Statlocker Button",
             true,
@@ -370,6 +387,7 @@ mod windows {
                 &exit_item,
                 &PredefinedMenuItem::separator(),
                 &hero_item,
+                &match_timer_item,
                 &statlocker_item,
                 &portrait_menu,
                 &PredefinedMenuItem::separator(),
@@ -381,6 +399,7 @@ mod windows {
         let launch_id = launch_item.id().clone();
         let exit_id = exit_item.id().clone();
         let hero_id = hero_item.id().clone();
+        let match_timer_id = match_timer_item.id().clone();
         let statlocker_id = statlocker_item.id().clone();
         let portrait_normal_id = portrait_normal_item.id().clone();
         let portrait_gloat_id = portrait_gloat_item.id().clone();
@@ -459,6 +478,11 @@ mod windows {
                         let new_val = !shared.show_hero_image.fetch_xor(true, Ordering::Relaxed);
                         hero_item.set_checked(new_val);
                         crate::config::set_config_bool("presence", "show_hero_image", new_val);
+                        shared.settings_dirty.store(true, Ordering::Relaxed);
+                    } else if event.id == match_timer_id {
+                        let new_val = !shared.show_match_timer.fetch_xor(true, Ordering::Relaxed);
+                        match_timer_item.set_checked(new_val);
+                        crate::config::set_config_bool("presence", "show_match_timer", new_val);
                         shared.settings_dirty.store(true, Ordering::Relaxed);
                     } else if event.id == statlocker_id {
                         let new_val = !shared.show_statlocker_button.fetch_xor(true, Ordering::Relaxed);


### PR DESCRIPTION
Closes #49.

Adds an optional match timer showing how long the current match has been running.

The Discord elapsed counter is unchanged (it still counts from when Deadlock RPC launched). The match duration is shown as a clock on the in-match status line instead:

`In Match: Standard Match - 07:42`

### Behaviour

- Counts from the `InMatch` transition (`gameinprogress`), not from loading or hero select. Repeated "game in progress" log signals do not restart the clock.
- Cleared on match end, hideout, main menu, queue, spectating, and game exit.
- Format is `MM:SS`, becoming `H:MM:SS` past an hour.
- The value is computed at push time, so it is exact when sent. Discord presence is only pushed every `discord_update_interval_s` (default 5s), so between pushes the displayed clock is up to that interval behind.
- The ticking clock never forces pushes faster than every 5s, so a low `discord_update_interval_s` cannot turn it into one Discord update per second.
- `presence.status.in_match` now supports a `{timer}` variable. If the template omits it (as every existing config does), the timer is appended automatically, so the feature works without editing config.

### Settings

- New key `presence.show_match_timer`, default `true`.
- Tray toggle **Settings → Show Match Timer** on both Linux and Windows, applied without a restart.
- No config migration needed: the key is new, so `merge_defaults` backfills it into existing configs and `config_version` stays at 2.

### Verification

- `cargo build` and `cargo clippy -- -D warnings` clean.
- Ran the app against a synthetic `console.log`: the status line ticked `00:00 → 00:05 → … → 00:30` at the default 5s interval, and cleared on match end.
- With `discord_update_interval_s = 1`, the timer still refreshed only every 5s.
- Confirmed `in_match = "In Match: {mode} [{timer}]"` places the timer inline, and `show_match_timer = false` removes it.
- Confirmed an existing v2 config without the key gains `show_match_timer = true` on launch with no version bump.